### PR TITLE
Include columns translated by the Globalize Gem

### DIFF
--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -123,6 +123,12 @@ module Jsonapi
           clos[col.name.to_sym] = { type: swagger_type(col), items_type: col.type, is_array: col.array,  nullable: col.null, comment: col.comment }
           clos[col.name.to_sym][:comment] = safe_encode(col.comment) if need_encoding
         end
+        model_klass.translation_class.columns.each do |col|
+          if model_klass.translated_attribute_names.include? col.name.to_sym
+            clos[col.name.to_sym] = { type: swagger_type(col), items_type: col.type, is_array: col.array,  nullable: col.null, comment: col.comment }
+            clos[col.name.to_sym][:comment] = safe_encode(col.comment) if need_encoding
+          end
+        end if model_klass.respond_to? :translation_class
       end
     end
 


### PR DESCRIPTION
When doing attribute translation using [Globalize](https://github.com/globalize/globalize) database columns are not created in the table for the model, instead they are created in a separate translation table. This PR checks to see if Globalize translations are in use, and then adds the relevant column data.