### PR TITLE
Allow paginator to be optional for resource.

### DIFF
--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -117,6 +117,10 @@ module Jsonapi
       resource_klass.mutable?
     end
 
+    def paginator
+      resource_klass.paginator
+    end
+
     def attribute_default
       Jsonapi::Swagger.attribute_default
     end

--- a/lib/generators/jsonapi/swagger/templates/swagger.json.erb
+++ b/lib/generators/jsonapi/swagger/templates/swagger.json.erb
@@ -5,8 +5,10 @@
   <%-
     def list_resource_parameters
       [].tap do |parameters|
-        parameters << { name: 'page[number]', in: :query, type: :string, description: tt(:page_num), required: false }
-        parameters << { name: 'page[size]', in: :query, type: :string, description: tt(:page_size), required: false }
+        if paginator == :paged
+          parameters << { name: 'page[number]', in: :query, type: :string, description: tt(:page_num), required: false }
+          parameters << { name: 'page[size]', in: :query, type: :string, description: tt(:page_size), required: false }
+        end
         if sortable_fields.present?
           parameters << { name: 'sort', in: :query, type: :string, description: ori_sortable_fields_desc, required: false }
         end
@@ -143,57 +145,63 @@
     end
 
     def list_resource_responses
+      response_properties = {
+        data: {
+          type: :array,
+          items: {
+            type: :object,
+            properties: {
+              id: { type: :string, description: 'ID' },
+              links: {
+                type: :object,
+                properties: {
+                  self: { type: :string, description: tt(:detail_link) },
+                },
+                description: tt(:detail_link)
+              },
+              attributes: {
+                type: :object,
+                properties: properties(attrs: attributes.each_key),
+                description: tt(:attributes)
+              },
+              relationships: {
+                type: :object,
+                properties: relationships_properties,
+                description: tt(:associate_data)
+              }
+            },
+          },
+          description: tt(:data)
+        }
+      }
+
+      unless paginator == :none
+        response_properties[:meta] = {
+          type: :object,
+          properties: {
+            record_count: { type: :integer, description: tt(:record_count)},
+            page_count: { type: :integer, description: tt(:page_count)},
+          },
+          description: tt(:meta)
+        }
+        response_properties[:links] = {
+          type: :object,
+          properties: {
+            first: { type: :string, description: tt(:first_page_link) },
+            next: { type: :string, description: tt(:next_page_link) },
+            last: { type: :string, description: tt(:last_page_link) },
+          },
+          description: tt(:page_links)
+        }
+      end
+
       {
         '200' => {
           description: tt(:get_list),
           schema: {
             type: :object,
-            properties: {
-              data: {
-                type: :array,
-                items: {
-                  type: :object,
-                  properties: {
-                    id: { type: :string, description: 'ID'},
-                    links: {
-                      type: :object,
-                      properties: {
-                      self: { type: :string, description: tt(:detail_link) },
-                    },
-                    description: tt(:detail_link)
-                  },
-                  attributes: {
-                    type: :object,
-                    properties: properties(attrs: attributes.each_key),
-                    description: tt(:attributes)
-                  },
-                  relationships: {
-                    type: :object,
-                    properties: relationships_properties,
-                    description: tt(:associate_data)
-                  }
-              },
-            },
-            description: tt(:data)
-            },
-            meta: {
-              type: :object,
-              properties: {
-                record_count: { type: :integer, description: tt(:record_count)},
-                page_count: { type: :integer, description: tt(:page_count)},
-              },
-              description: tt(:meta)
-            },
-            links: {
-              type: :object,
-              properties: {
-                first: { type: :string, description: tt(:first_page_link) },
-                next: { type: :string, description: tt(:next_page_link) },
-                last: { type: :string, description: tt(:last_page_link) },
-              },
-              description: tt(:page_links) },
-          },
-          required: [:data]
+            properties: response_properties,
+            required: [:data]
           }
         }
       }

--- a/lib/generators/jsonapi/swagger/templates/swagger.rb.erb
+++ b/lib/generators/jsonapi/swagger/templates/swagger.rb.erb
@@ -14,7 +14,9 @@ RSpec.describe '<%= resouces_name %>', type: :request do
     get '<%= route_resouces %> <%= t(:list) %>' do
       tags '<%= route_resouces %>'
       produces 'application/vnd.api+json'
+<% if paginator == :paged %>
       parameter name: :'page[number]', in: :query, type: :string, description: '<%= t(:page_num) %>', required: false
+<% end %>
 <% if sortable_fields.present? -%>
       parameter name: :'sort', in: :query, type: :string, description: '<%= sortable_fields_desc %>', required: false
 <% end -%>
@@ -80,6 +82,7 @@ RSpec.describe '<%= resouces_name %>', type: :request do
             },
             description: '<%= t(:data) %>'
             },
+<% unless paginator == :none %>
             meta: {
               type: :object,
               properties: {
@@ -95,7 +98,9 @@ RSpec.describe '<%= resouces_name %>', type: :request do
                 next: { type: :string, description: '<%= t(:next_page_link) %>'},
                 last: { type: :string, description: '<%= t(:last_page_link) %>'},
               },
-              description: '<%= t(:page_links) %>' },
+              description: '<%= t(:page_links) %>'
+            },
+<% end %>
           },
           required: [:data]
         run_test!

--- a/lib/jsonapi/swagger/resources/fast_jsonapi_resource.rb
+++ b/lib/jsonapi/swagger/resources/fast_jsonapi_resource.rb
@@ -34,6 +34,10 @@ module Jsonapi
       def mutable?
         false
       end
+
+      def paginator
+        :paged
+      end
     end
   end
 end

--- a/lib/jsonapi/swagger/resources/jsonapi_resource.rb
+++ b/lib/jsonapi/swagger/resources/jsonapi_resource.rb
@@ -5,7 +5,8 @@ module Jsonapi
       extend Forwardable
 
       def_delegators :@jr, :_attributes, :_relationships, :sortable_fields,
-                           :creatable_fields, :updatable_fields, :filters, :mutable?
+                           :creatable_fields, :updatable_fields, :filters, :mutable?,
+                           :_paginator
 
       def initialize(jr)
         @jr = jr
@@ -13,6 +14,7 @@ module Jsonapi
 
       alias attributes _attributes
       alias relationships _relationships
+      alias paginator _paginator
     end
   end
 end

--- a/lib/jsonapi/swagger/resources/serializable_resource.rb
+++ b/lib/jsonapi/swagger/resources/serializable_resource.rb
@@ -40,6 +40,10 @@ module Jsonapi
       def mutable?
         false
       end
+
+      def paginator
+        :paged
+      end
     end
   end
 end


### PR DESCRIPTION
This pull will add the page parameters, links and metadata when the `paged` paginator has been set for a resource or when it is the default for `JSONAPI::Resources`.

`FastJsonapi` and `SerializableResource` will default to the `paged` paginator for backwards compatibility.