### PR TITLE
Fixed an error that occurred when using this on mysql.

### DIFF
--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -132,14 +132,15 @@ module Jsonapi
         end
         model_klass.columns.each do |col|
           col_name = transform_method ? col.name.send(transform_method) : col.name
-          clos[col_name.to_sym] = { type: swagger_type(col), items_type: col.type, is_array: col.array,  nullable: col.null, comment: col.comment }
+          is_array = col.respond_to?(:array) ? col.array : false
+          clos[col_name.to_sym] = { type: swagger_type(col), items_type: col.type, is_array: is_array,  nullable: col.null, comment: col.comment }
           clos[col_name.to_sym][:comment] = safe_encode(col.comment) if need_encoding
         end
       end
     end
 
     def swagger_type(column)
-      return 'array' if column.array
+      return 'array' if column.respond_to?(:array) && column.array
 
       case column.type
       when :bigint, :integer then 'integer'


### PR DESCRIPTION
Fix error when using it on mysql.

```
     12: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:266:in `template'
        11: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:167:in `list_resource_responses'
        10: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:77:in `properties'
         9: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:77:in `tap'
         8: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:78:in `block in properties'
         7: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:78:in `each'
         6: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:78:in `each_key'
         5: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/templates/swagger.json.erb:79:in `block (2 levels) in properties'
         4: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/swagger_generator.rb:129:in `columns_with_comment'
         3: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/swagger_generator.rb:129:in `tap'
         2: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/swagger_generator.rb:133:in `block in columns_with_comment'
         1: from /home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/swagger_generator.rb:133:in `each'
/home/jksy/src/jksy/jsonapi-swagger/lib/generators/jsonapi/swagger/swagger_generator.rb:135:in `block (2 levels) in columns_with_comment': undefined method `array' for #<ActiveRecord::ConnectionAdapters::MySQL::Column:0x00000000065948d0> (NoMethodError)
```