### PR TITLE
Fix body parameter not using 'schema'. Also provide a default description. Also let basePath be nil.

### DIFF
--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -117,6 +117,11 @@ module Jsonapi
       resource_klass.filters
     end
 
+    # Static parameters that will be added to all end points for the class
+    def extra_parameters
+      resource_klass.extra_parameters
+    end
+
     def mutable?
       resource_klass.mutable?
     end

--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -45,6 +45,10 @@ module Jsonapi
       Jsonapi::Swagger.base_path
     end
 
+    def swagger_host
+      Jsonapi::Swagger.host
+    end
+
     def swagger_file_path
       Jsonapi::Swagger.file_path
     end

--- a/lib/generators/jsonapi/swagger/templates/swagger.json.erb
+++ b/lib/generators/jsonapi/swagger/templates/swagger.json.erb
@@ -1,7 +1,9 @@
 {
   "swagger": "<%= swagger_version %>",
   "info": <%= swagger_info %>,
-  "basePath" : "<%= swagger_base_path %>",
+  <% if !swagger_base_path.nil? %>
+    "basePath" : "<%= swagger_base_path %>",
+  <% end %>
   <%-
     def list_resource_parameters
       [].tap do |parameters|
@@ -40,30 +42,31 @@
       parameters = {
         name: :data,
         in: :body,
-        type: :object,
-        properties: {
-          data: {
-            type: :object,
-            properties: {
-              type: { type: :string, default: route_resouces },
-              attributes: {
-                type: :object,
-                properties: properties(attrs: creatable_fields)
+        schema: {
+          properties: {
+            data: {
+              type: :object,
+              properties: {
+                type: { type: :string, default: route_resouces },
+                attributes: {
+                  type: :object,
+                  properties: properties(attrs: creatable_fields)
+                }
               }
-            }
+            },
           },
-        },
-        description: tt(:request_body)
+          description: tt(:request_body)          
+        }
      }
-     parameters[:properties][:data][:properties][:relationships] ||= {}
-     parameters[:properties][:data][:properties][:relationships] = { type: :object, properties: create_relationships_properties }
+     parameters[:schema][:properties][:data][:properties][:relationships] ||= {}
+     parameters[:schema][:properties][:data][:properties][:relationships] = { type: :object, properties: create_relationships_properties }
      parameters
     end
 
     def patch_resource_parameters
       patch_parameters =  create_resource_parameters.dup
-      patch_parameters[:properties][:data][:properties][:id] ||= {}
-      patch_parameters[:properties][:data][:properties][:id].merge!({ type: :integer, description: 'ID' })
+      patch_parameters[:schema][:properties][:data][:properties][:id] ||= {}
+      patch_parameters[:schema][:properties][:data][:properties][:id].merge!({ type: :integer, description: 'ID' })
       parameters = [{ name: :id, in: :path, type: :integer, description: 'ID', required: true }]
       parameters << patch_parameters
       parameters
@@ -80,7 +83,7 @@
           props[attr][:type] = columns[attr][:type]
           props[attr][:items] = { type: columns[attr][:items_type] } if columns[attr][:is_array]
           props[attr][:'x-nullable'] = columns[attr][:nullable]
-          props[attr][:description] = columns[attr][:comment]
+          props[attr][:description] = columns[attr][:comment] || ""
         end
       end
     end

--- a/lib/generators/jsonapi/swagger/templates/swagger.json.erb
+++ b/lib/generators/jsonapi/swagger/templates/swagger.json.erb
@@ -1,5 +1,6 @@
 {
   "swagger": "<%= swagger_version %>",
+  "host": "<%= swagger_host %>",
   "info": <%= swagger_info %>,
   <% if !swagger_base_path.nil? %>
     "basePath" : "<%= swagger_base_path %>",

--- a/lib/generators/jsonapi/swagger/templates/swagger.json.erb
+++ b/lib/generators/jsonapi/swagger/templates/swagger.json.erb
@@ -23,6 +23,9 @@
         relationships.each_value do |relation|
           parameters << { name: :"fields[#{relation_table_name(relation)}]", in: :query, type: :string, description: tt(:display_field), required: false }
         end
+        if extra_parameters
+          parameters = parameters.concat(extra_parameters)
+        end
       end
     end
 
@@ -36,6 +39,9 @@
         relationships.each_value do |relation|
           parameters << { name: :"fields[#{relation_table_name(relation)}]", in: :query, type: :string, description: tt(:display_field), required: false }
         end
+        if extra_parameters
+          parameters = parameters.concat(extra_parameters)
+        end        
       end
     end
 
@@ -70,11 +76,18 @@
       patch_parameters[:schema][:properties][:data][:properties][:id].merge!({ type: :integer, description: 'ID' })
       parameters = [{ name: :id, in: :path, type: :integer, description: 'ID', required: true }]
       parameters << patch_parameters
+      if extra_parameters
+        parameters = parameters.concat(extra_parameters)
+      end      
       parameters
     end
 
     def delete_resource_parameters
-      [{ name: :id, in: :path, type: :integer, description: 'ID', required: true }]
+      parameters = [{ name: :id, in: :path, type: :integer, description: 'ID', required: true }]
+      if extra_parameters
+        parameters = parameters.concat(extra_parameters)
+      end
+      parameters      
     end
 
     def properties(attrs: [])

--- a/lib/jsonapi/swagger.rb
+++ b/lib/jsonapi/swagger.rb
@@ -10,7 +10,7 @@ module Jsonapi
     class Error < StandardError; end
 
     class << self
-      attr_accessor :version, :info, :file_path, :base_path, :use_rswag
+      attr_accessor :version, :info, :file_path, :base_path, :use_rswag, :host
 
       def config
         yield self
@@ -30,6 +30,10 @@ module Jsonapi
 
       def base_path
         @base_path
+      end
+
+      def host
+        @host
       end
 
       def use_rswag

--- a/lib/jsonapi/swagger/json.rb
+++ b/lib/jsonapi/swagger/json.rb
@@ -16,6 +16,10 @@ module Jsonapi
         Jsonapi::Swagger.base_path
       end
 
+      def host
+        Jsonapi::Swagger.host
+      end
+
       def load
         @data ||= if File.exist?(path)
                   IO.read(path)

--- a/lib/jsonapi/swagger/resources/jsonapi_resource.rb
+++ b/lib/jsonapi/swagger/resources/jsonapi_resource.rb
@@ -5,7 +5,7 @@ module Jsonapi
       extend Forwardable
 
       def_delegators :@jr, :_attributes, :_relationships, :sortable_fields,
-                           :creatable_fields, :updatable_fields, :filters, :mutable?
+                           :creatable_fields, :updatable_fields, :filters, :mutable?, :extra_parameters
 
       def initialize(jr)
         @jr = jr


### PR DESCRIPTION
Few changes here (happy to open separate PRs if you prefer).

1. Use 'schema' in body params instead of 'type'.
OpenAPI requires a `"in": "body"` parameter to use a `schema` instead of `type`. This lib was hard coding to use `type` so I switched it to use `schema`.
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
^ Note "If in is "body":"...schema is Required.


2. Provide a default empty string description because a `null` doesn't pass many swagger validators.

3. Allow basePath to be nil
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields
^ Note here that `basePath` can be unspecified (omitted from the json)