### PR TITLE
Fix invalid keyword arguments on ruby 3

### DIFF
--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -162,7 +162,7 @@ module Jsonapi
     def tt(key, options={})
       options[:scope] = :jsonapi_swagger
       options[:default] = key.to_s.humanize
-      I18n.t(key, options)
+      I18n.t(key, **options)
     end
 
     def safe_encode(content)


### PR DESCRIPTION
This fixes where the generator attempts to call `I18n.t(key, params)` where `params` is a hash while `I18n.t[ranslate]` expects kwargs. Support for this behavior was removed in ruby 3.

See also #12 